### PR TITLE
autoinstaller: make wheel permission come first, fix permissions

### DIFF
--- a/dracut/autoinstaller/install.sh
+++ b/dracut/autoinstaller/install.sh
@@ -81,7 +81,8 @@ VAI_prepare_chroot() {
 
 VAI_configure_sudo() {
     # Give wheel sudo
-    echo "%wheel ALL=(ALL:ALL) ALL" > "${target}/etc/sudoers.d/wheel"
+    echo "%wheel ALL=(ALL:ALL) ALL" > "${target}/etc/sudoers.d/00-wheel"
+    chmod 0440 "${target}/etc/sudoers.d/00-wheel"
 }
 
 VAI_correct_root_permissions() {


### PR DESCRIPTION
visudo -c shows perms need 0440

Also w is late in the alphabet, hard to alter ordering